### PR TITLE
added ttyMFD* to baselist

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -45,6 +45,7 @@ def serialList():
 	baselist = baselist \
 			   + glob.glob("/dev/ttyUSB*") \
 			   + glob.glob("/dev/ttyACM*") \
+			   + glob.glob("/dev/ttyMFD*") \
 			   + glob.glob("/dev/ttyAMA*") \
 			   + glob.glob("/dev/tty.usb*") \
 			   + glob.glob("/dev/cu.*") \


### PR DESCRIPTION
Intel Edison's UART is /dev/ttyMFD\* so this was added to the baselist to communicate with a printer attached via serial on the Intel Edison board.
